### PR TITLE
updated code to allow for pluggable parsing options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+.idea

--- a/file.go
+++ b/file.go
@@ -208,12 +208,19 @@ type File struct {
 	Flows  []Flow
 }
 
-func ParseReader(r io.Reader) (sf File, err error) {
+func ParseReader(r io.Reader, receiver FlowReceiver) (sf File, err error) {
+	parsedFlows := NewSliceFlowReceiver(4096)
+	err = parseReader(r, parsedFlows)
+	if err != nil {
+		return File{}, err
+	}
 
-	return parseReader(r)
+	return parsedFlows.File, nil
 }
 
-func parseReader(f io.Reader) (sf File, err error) {
+func parseReader(f io.Reader, receiver FlowReceiver) (err error) {
+	defer receiver.Close()
+
 	var n int
 	var x int
 	var start int
@@ -231,18 +238,21 @@ func parseReader(f io.Reader) (sf File, err error) {
 	var o offsets
 	var ro io.ReadCloser
 	var isTCP uint32
+	var header Header
 
-	if sf.Header, err = parseHeader(f); err != nil {
+	if header, err = parseHeader(f); err != nil {
 		return
 	}
 
-	if o, err = getOffsets(sf.Header.RecordSize); err != nil {
+	receiver.HandleHeader(header)
+
+	if o, err = getOffsets(header.RecordSize); err != nil {
 		return
 	}
 
-	if sf.Header.Compression == 0 {
-		mod := math.Floor(float64(defaultReadSize) / float64(sf.Header.RecordSize))
-		readSize := (int(mod) * int(sf.Header.RecordSize))
+	if header.Compression == 0 {
+		mod := math.Floor(float64(defaultReadSize) / float64(header.RecordSize))
+		readSize := (int(mod) * int(header.RecordSize))
 		decompressedBuffer = make([]byte, readSize)
 	}
 
@@ -250,7 +260,7 @@ func parseReader(f io.Reader) (sf File, err error) {
 	for {
 		blockCount++
 		// log.Printf("blockCount:%d", blockCount)
-		switch sf.Header.Compression {
+		switch header.Compression {
 		case 0:
 			if n, err = f.Read(decompressedBuffer); n == 0 && err == io.EOF {
 				err = nil
@@ -258,8 +268,8 @@ func parseReader(f io.Reader) (sf File, err error) {
 			} else if err != nil {
 				err = fmt.Errorf("Read error:%s", err.Error())
 				return
-			} else if n < int(sf.Header.RecordSize) {
-				err = fmt.Errorf("Read:%d smaller then record size:%d", n, sf.Header.RecordSize)
+			} else if n < int(header.RecordSize) {
+				err = fmt.Errorf("Read:%d smaller then record size:%d", n, header.RecordSize)
 				return
 			} else if n < len(decompressedBuffer) {
 				shortReadCount++
@@ -271,9 +281,9 @@ func parseReader(f io.Reader) (sf File, err error) {
 				shortReadCount = 0
 			}
 
-			recordsCount = n / int(sf.Header.RecordSize)
+			recordsCount = n / int(header.RecordSize)
 
-			if readMod = math.Mod(float64(n), float64(sf.Header.RecordSize)); readMod != 0 {
+			if readMod = math.Mod(float64(n), float64(header.RecordSize)); readMod != 0 {
 				err = ErrUnsupportedPartialRead
 				return
 			}
@@ -300,15 +310,15 @@ func parseReader(f io.Reader) (sf File, err error) {
 			} else if err != nil {
 				return
 			}
-			if sf.Header.Compression == 3 {
+			if header.Compression == 3 {
 				if _, err = snappy.Decode(decompressedBuffer, compressedBuffer[:compressedBlockSize]); err != nil {
 					return
 				}
-			} else if sf.Header.Compression == 2 {
+			} else if header.Compression == 2 {
 				if decompressedBuffer, err = lzo.Decompress1X(bytes.NewReader(compressedBuffer[:compressedBlockSize]), 0, 0); err != nil {
 					return
 				}
-			} else if sf.Header.Compression == 1 {
+			} else if header.Compression == 1 {
 				if ro, err = zlib.NewReader(bytes.NewReader(compressedBuffer[:compressedBlockSize])); err != nil {
 					return
 				}
@@ -319,14 +329,14 @@ func parseReader(f io.Reader) (sf File, err error) {
 				ro.Close()
 			}
 
-			recordsCount = int(decompressedBlockSize) / int(sf.Header.RecordSize)
+			recordsCount = int(decompressedBlockSize) / int(header.RecordSize)
 		default:
 			err = ErrUnsupportedCompression
 			return
 		}
 
 		start = 0
-		end = int(sf.Header.RecordSize)
+		end = int(header.RecordSize)
 		for x = 0; x < recordsCount; x++ {
 			//Clear out struct values
 			silkFlow.startTimeMS56 = 0
@@ -350,11 +360,11 @@ func parseReader(f io.Reader) (sf File, err error) {
 			silkFlow.SNMPOut = 0
 			silkFlow.NextHopIP = nil
 
-			if sf.Header.FileFlags == 0 {
+			if header.FileFlags == 0 {
 				//little endian
-				if sf.Header.RecordSize == 56 {
+				if header.RecordSize == 56 {
 					silkFlow.startTimeMS56 = binary.LittleEndian.Uint32(decompressedBuffer[start:end][o.startStartTime:o.endStartTime])
-					silkFlow.StartTimeMS = uint64((calMsec & silkFlow.startTimeMS56)) + sf.Header.fileDateMS
+					silkFlow.StartTimeMS = uint64((calMsec & silkFlow.startTimeMS56)) + header.fileDateMS
 					isTCP = silkFlow.startTimeMS56 & isTCPAnd
 					if isTCP != 0 {
 						silkFlow.Proto = 6
@@ -381,7 +391,7 @@ func parseReader(f io.Reader) (sf File, err error) {
 				silkFlow.Bytes = binary.LittleEndian.Uint32(decompressedBuffer[start:end][o.startBytes:o.endBytes])
 				silkFlow.Duration = binary.LittleEndian.Uint32(decompressedBuffer[start:end][o.startDuration:o.endDuration])
 
-				if sf.Header.RecordSize == 88 {
+				if header.RecordSize == 88 {
 					silkFlow.SNMPIn = binary.LittleEndian.Uint16(decompressedBuffer[start:end][o.startSNMPIn:o.endSNMPIn])
 					silkFlow.SNMPOut = binary.LittleEndian.Uint16(decompressedBuffer[start:end][o.startSNMPOut:o.endSNMPOut])
 					silkFlow.NextHopIP = net.ParseIP(net.IP(decompressedBuffer[start:end][o.startNextHopIP:o.endNextHopIP]).String())
@@ -389,21 +399,21 @@ func parseReader(f io.Reader) (sf File, err error) {
 					silkFlow.Application = binary.LittleEndian.Uint16(decompressedBuffer[start:end][o.startApplication:o.endApplication])
 				}
 
-				if sf.Header.RecordSize == 88 || sf.Header.RecordSize == 68 {
+				if header.RecordSize == 88 || header.RecordSize == 68 {
 					silkFlow.ClassType = decompressedBuffer[o.startClassType]
 					silkFlow.Sensor = binary.LittleEndian.Uint16(decompressedBuffer[start:end][o.startSensor:o.endSensor])
 					silkFlow.InitalFlags = decompressedBuffer[o.startInitalFlags]
 					silkFlow.SessionFlags = decompressedBuffer[o.startSessionFlags]
 					silkFlow.Attributes = decompressedBuffer[o.startAttributes]
-				} else if sf.Header.RecordSize == 56 {
-					silkFlow.Sensor = uint16(sf.Header.fileSensor)
+				} else if header.RecordSize == 56 {
+					silkFlow.Sensor = uint16(header.fileSensor)
 				}
 
 			} else {
 				//big endian)
-				if sf.Header.RecordSize == 56 {
+				if header.RecordSize == 56 {
 					silkFlow.startTimeMS56 = binary.BigEndian.Uint32(decompressedBuffer[start:end][o.startStartTime:o.endStartTime])
-					silkFlow.StartTimeMS = uint64((calMsec & silkFlow.startTimeMS56)) + sf.Header.fileDateMS
+					silkFlow.StartTimeMS = uint64((calMsec & silkFlow.startTimeMS56)) + header.fileDateMS
 					isTCP = silkFlow.startTimeMS56 & isTCPAnd
 					if isTCP != 0 {
 						silkFlow.Proto = 6
@@ -429,7 +439,7 @@ func parseReader(f io.Reader) (sf File, err error) {
 				silkFlow.Bytes = binary.BigEndian.Uint32(decompressedBuffer[start:end][o.startBytes:o.endBytes])
 				silkFlow.Duration = binary.BigEndian.Uint32(decompressedBuffer[start:end][o.startDuration:o.endDuration])
 
-				if sf.Header.RecordSize == 88 {
+				if header.RecordSize == 88 {
 					silkFlow.SNMPIn = binary.BigEndian.Uint16(decompressedBuffer[start:end][o.startSNMPIn:o.endSNMPIn])
 					silkFlow.SNMPOut = binary.BigEndian.Uint16(decompressedBuffer[start:end][o.startSNMPOut:o.endSNMPOut])
 					copy(silkFlow.NextHopIP, decompressedBuffer[start:end][o.startNextHopIP:o.endNextHopIP])
@@ -438,20 +448,20 @@ func parseReader(f io.Reader) (sf File, err error) {
 					silkFlow.Application = binary.BigEndian.Uint16(decompressedBuffer[start:end][o.startApplication:o.endApplication])
 				}
 
-				if sf.Header.RecordSize == 88 || sf.Header.RecordSize == 68 {
+				if header.RecordSize == 88 || header.RecordSize == 68 {
 					silkFlow.Sensor = binary.BigEndian.Uint16(decompressedBuffer[start:end][o.startSensor:o.endSensor])
 					silkFlow.InitalFlags = decompressedBuffer[o.startInitalFlags]
 					silkFlow.SessionFlags = decompressedBuffer[o.startSessionFlags]
 					silkFlow.Attributes = decompressedBuffer[o.startAttributes]
 					silkFlow.ClassType = decompressedBuffer[o.startClassType]
-				} else if sf.Header.RecordSize == 56 {
-					silkFlow.Sensor = uint16(sf.Header.fileSensor)
+				} else if header.RecordSize == 56 {
+					silkFlow.Sensor = uint16(header.fileSensor)
 				}
 			}
 
-			sf.Flows = append(sf.Flows, silkFlow)
-			start += int(sf.Header.RecordSize)
-			end += int(sf.Header.RecordSize)
+			receiver.HandleFlow(silkFlow)
+			start += int(header.RecordSize)
+			end += int(header.RecordSize)
 		}
 	}
 	return
@@ -471,6 +481,32 @@ func OpenFile(filePath string) (sf File, err error) {
 	}
 	var r2 = bytes.NewReader(data)
 
-	return parseReader(r2)
+	parsedFlows := NewSliceFlowReceiver(4096)
+	err = parseReader(r2, parsedFlows)
+	if err != nil {
+		return File{}, err
+	}
 
+	return parsedFlows.File, nil
+}
+
+func Parse(filePath string, receiver FlowReceiver) (err error) {
+	var f *os.File
+
+	if f, err = os.Open(filePath); err != nil {
+		return
+	}
+	var r = bufio.NewReader(f)
+	var data []byte
+	if data, err = ioutil.ReadAll(r); err != nil {
+		return
+	}
+	var r2 = bytes.NewReader(data)
+
+	err = parseReader(r2, receiver)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/file_test.go
+++ b/file_test.go
@@ -283,6 +283,105 @@ func TestFiles(t *testing.T) {
 
 }
 
+//TestParse Test all supported file formats using an alternative flow receiver
+func TestParse(t *testing.T) {
+	t.Logf("TestFiles()")
+	var testData = []testDetails{
+		getTestDataFTRWIPV6V2(),          //56 byte
+		getTestDataFTRWIPV6V1(),          //68 byte
+		getTestDataFTRWIPV6ROUTINGV6V2(), //88 byte
+	}
+	for _, testFlowData := range testData {
+		for _, filePath := range testFlowData.files {
+			var err error
+			receiver := NewChannelFlowReceiver(0)
+			flows := make([]Flow, 0, 245340)
+			go func() {
+				if err = Parse(filePath, receiver); err != nil {
+					t.Errorf("OpenFile file:%s error:%s", filePath, err)
+				}
+			}()
+
+			for flow := range receiver.Read() {
+				flows = append(flows, flow)
+			}
+
+			if len(flows) != 245340 {
+				t.Errorf("File:%s Rows found:%d, rows expected:%d", filePath, len(flows), 245340)
+			}
+			if len(flows) < len(testFlowData.flows) {
+				t.Errorf("Test file:%s has fewer rows:%d then test:%d", filePath, len(flows), len(testFlowData.flows))
+			}
+
+			for x := 0; x < len(testFlowData.flows); x++ {
+
+				if len(flows) <= x {
+					break
+				}
+
+				if flows[x].SrcPort != testFlowData.flows[x].SrcPort {
+					t.Errorf("Test SrcPort:%d not equal to data row:%d file:%s", testFlowData.flows[x].SrcPort, flows[x].SrcPort, filePath)
+				}
+				if flows[x].DstPort != testFlowData.flows[x].DstPort {
+					t.Errorf("Test DstPort:%d not equal to data row:%d file:%s", testFlowData.flows[x].DstPort, flows[x].DstPort, filePath)
+				}
+				if flows[x].SrcIP.String() != testFlowData.flows[x].SrcIP.String() {
+					t.Errorf("Test SrcIP:%s not equal to data row:%s file:%s", testFlowData.flows[x].SrcIP.String(), flows[x].SrcIP.String(), filePath)
+				}
+				if flows[x].DstIP.String() != testFlowData.flows[x].DstIP.String() {
+					t.Errorf("Test DstIP:%s not equal to data row:%s file:%s", testFlowData.flows[x].DstIP.String(), flows[x].DstIP.String(), filePath)
+				}
+				if flows[x].Proto != testFlowData.flows[x].Proto {
+					t.Errorf("Test Proto:%d not equal to data row:%d file:%s", testFlowData.flows[x].Proto, flows[x].Proto, filePath)
+				}
+				if flows[x].Packets != testFlowData.flows[x].Packets {
+					t.Errorf("Test Packets:%d not equal to data row:%d file:%s", testFlowData.flows[x].Packets, flows[x].Packets, filePath)
+				}
+				if flows[x].Bytes != testFlowData.flows[x].Bytes {
+					t.Errorf("Test Bytes:%d not equal to data row:%d file:%s", testFlowData.flows[x].Bytes, flows[x].Bytes, filePath)
+				}
+				if flows[x].Flags != testFlowData.flows[x].Flags {
+					t.Errorf("Test Flags:%d not equal to data row:%d file:%s", testFlowData.flows[x].Flags, flows[x].Flags, filePath)
+				}
+				if flows[x].StartTimeMS != testFlowData.flows[x].StartTimeMS {
+					t.Errorf("Test StartTimeMS:%d not equal to data row:%d file:%s", testFlowData.flows[x].StartTimeMS, flows[x].StartTimeMS, filePath)
+				}
+				if flows[x].Sensor != testFlowData.flows[x].Sensor {
+					t.Errorf("Test Sensor:%d not equal to data row:%d file:%s", testFlowData.flows[x].Sensor, flows[x].Sensor, filePath)
+				}
+				if flows[x].Duration != testFlowData.flows[x].Duration {
+					t.Errorf("Test Duration:%d not equal to data row:%d file:%s", testFlowData.flows[x].Duration, flows[x].Duration, filePath)
+				}
+				if flows[x].SNMPIn != testFlowData.flows[x].SNMPIn {
+					t.Errorf("Test SNMPIn:%d not equal to data row:%d file:%s", testFlowData.flows[x].SNMPIn, flows[x].SNMPIn, filePath)
+				}
+				if flows[x].SNMPOut != testFlowData.flows[x].SNMPOut {
+					t.Errorf("Test SNMPOut:%d not equal to data row:%d file:%s", testFlowData.flows[x].SNMPOut, flows[x].SNMPOut, filePath)
+				}
+				if flows[x].NextHopIP.Equal(testFlowData.flows[x].NextHopIP) == false {
+					t.Errorf("Test NextHopIP:%s not equal to data row:%s file:%s", testFlowData.flows[x].NextHopIP.String(), flows[x].NextHopIP.String(), filePath)
+				}
+				if flows[x].ClassType != testFlowData.flows[x].ClassType {
+					t.Errorf("Test ClassType:%d not equal to data row:%d file:%s", testFlowData.flows[x].ClassType, flows[x].ClassType, filePath)
+				}
+				if flows[x].InitalFlags != testFlowData.flows[x].InitalFlags {
+					t.Errorf("Test InitalFlags:%d not equal to data row:%d file:%s", testFlowData.flows[x].InitalFlags, flows[x].InitalFlags, filePath)
+				}
+				if flows[x].SessionFlags != testFlowData.flows[x].SessionFlags {
+					t.Errorf("Test SessionFlags:%d not equal to data row:%d file:%s", testFlowData.flows[x].SessionFlags, flows[x].SessionFlags, filePath)
+				}
+				if flows[x].Attributes != testFlowData.flows[x].Attributes {
+					t.Errorf("Test Attributes:%d not equal to data row:%d file:%s", testFlowData.flows[x].Attributes, flows[x].Attributes, filePath)
+				}
+				if flows[x].Application != testFlowData.flows[x].Application {
+					t.Errorf("Test Application:%d not equal to data row:%d file:%s", testFlowData.flows[x].Application, flows[x].Application, filePath)
+				}
+			}
+		}
+	}
+
+}
+
 //getBenchFileList returns list of all supported test files
 func getBenchFileList() []string {
 	return []string{

--- a/receivers.go
+++ b/receivers.go
@@ -1,0 +1,59 @@
+package silk
+
+type FlowReceiver interface {
+	HandleHeader(h Header)
+	HandleFlow(f Flow)
+	Close()
+}
+
+type SliceFlowReceiver struct {
+	File
+}
+
+func NewSliceFlowReceiver(initialSize int) *SliceFlowReceiver {
+	return &SliceFlowReceiver{
+		File{
+			Flows: make([]Flow, 0, initialSize),
+		},
+	}
+}
+
+func (a *SliceFlowReceiver) HandleHeader(h Header) {
+	a.Header = h
+}
+
+func (a *SliceFlowReceiver) HandleFlow(f Flow) {
+	a.Flows = append(a.Flows, f)
+}
+
+func (a *SliceFlowReceiver) Close() {
+	// Nothing to do in the slice case
+}
+
+type ChannelFlowReceiver struct {
+	Header    Header
+	rwChannel chan Flow
+}
+
+func NewChannelFlowReceiver(channelBufferSize int) *ChannelFlowReceiver {
+	rwChannel := make(chan Flow, channelBufferSize)
+	return &ChannelFlowReceiver{
+		rwChannel: rwChannel,
+	}
+}
+
+func (c ChannelFlowReceiver) Read() <-chan Flow {
+	return c.rwChannel
+}
+
+func (c *ChannelFlowReceiver) HandleHeader(h Header) {
+	c.Header = h
+}
+
+func (c *ChannelFlowReceiver) HandleFlow(f Flow) {
+	c.rwChannel <- f
+}
+
+func (c *ChannelFlowReceiver) Close() {
+	close(c.rwChannel)
+}


### PR DESCRIPTION
Added a new FlowReceiver interface which allows for the user to pass in their own custom way of receiving flows. This opens up the ability to "stream" flows back. 2 implementations of FlowReciever were created:
* SliceFlowReceiver - used to ensure that no apis were broken with this update
* ChannelFlowReceiver - adds a streaming style parsing option